### PR TITLE
Replaces gitHeadWatchInterval with repository.state.onDidChange

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Run Tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,13 @@ name: Run Tests
 on: [push]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        vscode_version: ['1.86.0', '1.91.0']
+    name: ${{ matrix.os }} / VSCode ${{ matrix.vscode_version }}
 
     steps:
     - name: Checkout code
@@ -20,3 +25,12 @@ jobs:
 
     - name: Run tests with xvfb
       run: xvfb-run -a npm test
+      if: runner.os == 'Linux'
+      env:
+        VSCODE_VERSION: ${{ matrix.vscode_version }}
+
+    - name: Run tests
+      run: npm test
+      if: runner.os != 'Linux'
+      env:
+        VSCODE_VERSION: ${{ matrix.vscode_version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
-# Change Log
+## Unreleased
 
-All notable changes to the "jira-commit-message" extension will be documented in this file.
+- Removal of `gitHeadWatchInterval`, instead the `onDidChange` event of the GitExtension is used
 
-Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+## [0.0.7] (https://github.com/kivicode/Jira-Commit-Message/compare/0.0.7...0.0.6)
 
-## [Unreleased]
-
-- Initial release
+- Settings are reloaded on change not requiring restart of vscode anymore #2

--- a/package.json
+++ b/package.json
@@ -56,11 +56,6 @@
           "type": "string",
           "default": "[${prefix}] ${message}",
           "description": "Format for the commit message with prefix. Use ${prefix} for the branch prefix and ${message} for the original commit message."
-        },
-        "jira-commit-message.gitHeadWatchInterval": {
-          "type": "number",
-          "default": 1000,
-          "description": "Interval in milliseconds at which to watch the .git/HEAD file for changes."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,7 +22,7 @@ class RepositoryWatcher {
     this.repo = repo;
     this.config = config;
 
-    this.log(`Watching repository: ${this.repo.rootUri.fsPath}`);
+    this.log(`Watching ${this.repo.rootUri}`);
     this.setupWatchers();
     this.safeUpdateCommitMessage(); // Initial update
   }
@@ -33,7 +33,7 @@ class RepositoryWatcher {
 
   private safeUpdateCommitMessage(currentMessage?: string) {
     try {
-      updateCommitMessage(this.repo, this.config, currentMessage);
+      updateCommitMessage(this.repo, this.config, (msg) => this.log(msg), currentMessage);
     } catch (error) {
       this.log(`Error updating commit message: ${(error as Error).message}`);
     }
@@ -57,7 +57,7 @@ class RepositoryWatcher {
     // Cleanup gitHeadWatcher and file watchers
     this.watcher?.dispose();
     
-    this.log(`Stopped watching repository: ${this.repo.rootUri.fsPath}`);
+    this.log(`Stopped watching repository: ${this.repo.rootUri}`);
   }
 }
 
@@ -90,10 +90,12 @@ function getExtensionConfig(): ExtensionConfig {
 function updateCommitMessage(
   repo: Repository,
   config: ExtensionConfig,
+  log: (message: string) => void,
   currentMessage?: string
 ): void {
   const branch: string = repo.state.HEAD?.name ?? "";
   if (!branch) {
+    log(`repo.state.HEAD is empty. Skipping`);
     return;
   }
 
@@ -104,7 +106,10 @@ function updateCommitMessage(
   const updatedMessage = getCommitMessage(branch, currentMessage, config);
 
   if (repo.inputBox.value !== updatedMessage) {
+    log(`Updating commit message "${repo.inputBox.value}" on branch ${branch} to "${updatedMessage}"`);
     repo.inputBox.value = updatedMessage;
+  } else {
+    log(`Commit message on branch ${branch} is already "${updatedMessage}".`);
   }
 }
 
@@ -160,6 +165,11 @@ export function activate(context: vscode.ExtensionContext): void {
   }
   const git = gitExtension.getAPI(1);
   let config = getExtensionConfig();
+  outputChannel.appendLine(
+    `${LOG_PREFIX} Loaded configuration ${JSON.stringify(config)}`
+  );
+
+
 
   const repoWatchers: RepositoryWatcher[] = [];
 
@@ -174,10 +184,19 @@ export function activate(context: vscode.ExtensionContext): void {
       (watcher) => watcher.repo === repo
     );
     if (existingWatcher) {
+      outputChannel.appendLine(`${LOG_PREFIX} Already watching ${repo.rootUri}`);
       return;
-    }
+    } 
     const watcher = new RepositoryWatcher(repo, config, outputChannel);
     repoWatchers.push(watcher);
+  };
+
+  const removeRepoWatcher = (repo: Repository): void => {
+    const index = repoWatchers.findIndex((watcher) => watcher.repo.rootUri.toString() === repo.rootUri.toString());
+    if (index !== -1) {
+      repoWatchers[index].dispose();
+      repoWatchers.splice(index, 1);
+    }
   };
 
   updateRepositoryWatchers(config);
@@ -185,22 +204,31 @@ export function activate(context: vscode.ExtensionContext): void {
   const configSubscription = vscode.workspace.onDidChangeConfiguration(
     (event) => {
       if (event.affectsConfiguration("jira-commit-message")) {
-        outputChannel.appendLine(
-          `${LOG_PREFIX} Configuration changed, updating...`
-        );
         config = getExtensionConfig();
+        outputChannel.appendLine(
+          `${LOG_PREFIX} Configuration changed to ${JSON.stringify(config)}`
+        );
         updateRepositoryWatchers(config);
       }
     }
   );
 
-  const repositorySubscription = git.onDidOpenRepository(addRepoWatcher);
-
-  git.repositories.forEach(addRepoWatcher);
+  (git.state === "initialized"? Promise.resolve() : new Promise<void>((resolve) => {
+    git.onDidChangeState((state) => {
+      if (state === 'initialized') {
+        resolve();
+      }
+    });
+  })).then(
+    () => {
+      git.repositories.forEach(addRepoWatcher);
+      context.subscriptions.push(git.onDidOpenRepository(addRepoWatcher));
+      context.subscriptions.push(git.onDidCloseRepository(removeRepoWatcher));
+    }
+  );
 
   context.subscriptions.push(
     configSubscription,
-    repositorySubscription,
     new vscode.Disposable(() => {
       while (repoWatchers.length > 0) {
         const watcher = repoWatchers.pop();
@@ -212,10 +240,8 @@ export function activate(context: vscode.ExtensionContext): void {
       () => {
         git.repositories.forEach((repo) => {
           try {
-            updateCommitMessage(repo, config);
-            outputChannel.appendLine(
-              `${LOG_PREFIX} Commit message updated via command.`
-            );
+            updateCommitMessage(repo, config, (msg) => outputChannel.appendLine(
+              `${LOG_PREFIX}  ${msg}`));
           } catch (error) {
             outputChannel.appendLine(
               `${LOG_PREFIX} Error executing update command: ${

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -18,7 +18,7 @@ async function main() {
     await runTests({
       extensionDevelopmentPath,
       extensionTestsPath,
-      version: "1.86.0",
+      version: process.env.VSCODE_VERSION || "1.86.0",
       launchArgs: ["--disable-gpu", workspaceFolder],
     });
   } catch (err) {

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -80,6 +80,10 @@ suite("Jira Commit Message Extension", function () {
         throw new Error("unexpected");
       }
 
+      await updateConfig({
+        commitMessageFormat: "${prefix} ${message}"
+      });
+
       await initializeGitRepository(workspaceFolders[0].uri);
     } catch (e) {
       console.error(e);
@@ -156,7 +160,6 @@ suite("Jira Commit Message Extension", function () {
 
   interface ExtensionConfig {
     commitMessagePrefixPattern?: string;
-    gitHeadWatchInterval?: number;
     commitMessageFormat?: string;
   }
 
@@ -175,11 +178,6 @@ suite("Jira Commit Message Extension", function () {
     updateIfNecessary(
       "commitMessagePrefixPattern",
       extensionConfig.commitMessagePrefixPattern
-    );
-
-    updateIfNecessary(
-      "gitHeadWatchInterval",
-      extensionConfig.gitHeadWatchInterval
     );
 
     updateIfNecessary(

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,12 +1,12 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
 
-import { after, before, suite, test, beforeEach } from "mocha";
+import { before, suite, test, beforeEach } from "mocha";
 import { GitExtension } from "../../git";
 
 const disableTimeouts = process.env.DISABLE_TIMEOUTS === "true";
 
-const GIT_WATCH_INTERVAL = 1000;
+const GIT_WAIT_INTERVAL = 1500;
 
 suite("Jira Commit Message Extension", function () {
   this.timeout(disableTimeouts ? 0 : 30000);
@@ -57,7 +57,7 @@ suite("Jira Commit Message Extension", function () {
 
     // Wait for the extension to catch up
     await new Promise((resolve) =>
-      setTimeout(resolve, GIT_WATCH_INTERVAL + 10)
+      setTimeout(resolve, GIT_WAIT_INTERVAL)
     );
   }
 
@@ -73,12 +73,6 @@ suite("Jira Commit Message Extension", function () {
 
       const git: GitExtension = gitExtension.exports;
       gitApi = git.getAPI(1);
-
-      await updateConfig({
-        gitHeadWatchInterval: GIT_WATCH_INTERVAL,
-        commitMessageFormat: "${prefix} ${message}",
-        commitMessagePrefixPattern: "(PP-\\d+)-.*",
-      });
 
       const workspaceFolders = vscode.workspace.workspaceFolders;
 
@@ -101,6 +95,10 @@ suite("Jira Commit Message Extension", function () {
   });
 
   test("should update commit message when switching to a branch matching prefix pattern", async function () {
+    // Must set patters at start to avoid patterns leaking in from other tests
+    await updateConfig({
+      commitMessagePrefixPattern: "(PP-\\d+)-.*",
+    });
     const repo = gitApi.repositories[0];
 
     repo.inputBox.value = "Test feature implementation";
@@ -109,6 +107,10 @@ suite("Jira Commit Message Extension", function () {
   });
 
   test("should not modify commit message for branches not matching prefix pattern", async function () {
+    // Must set patters at start to avoid patterns leaking in from other tests
+    await updateConfig({
+      commitMessagePrefixPattern: "(PP-\\d+)-.*",
+    });
     const repo = gitApi.repositories[0];
 
     repo.inputBox.value = "Test non matching branch commit";


### PR DESCRIPTION
In the last MR, I noticed that there was a discrepancy between the file watchers and the usage of the GitExtension that were causing issues in the test. When the `gitHeadWatchInterval` is set to a low value below `500` (although I haven't done extensive testing on it), the test started failing. The reason is that that the `repo.state` wasn't updated yet (and was still returning the old branch). 
This line was causing the problem:

https://github.com/kivicode/Jira-Commit-Message/blob/5337f432f30b35694118b4278a17d3b5a89f5d2b/src/extension.ts#L182

Last time, I also noticed that the `RepositoryState` provides an `onDidChange` method:

https://github.com/kivicode/Jira-Commit-Message/blob/5337f432f30b35694118b4278a17d3b5a89f5d2b/src/git.d.ts#L128

With this method, we have the guarantee that `repo.state` is updated.

I then checked how the GitExtension is doing the file watching. It is using `fs.watch`, this extension currently uses `fs.watchFile`. The difference between the two is that `fs.watchFile` does active polling, and `fs.watch` uses the fs integration to get notified of the changes. 

The file watching in vscode is implemented in https://github.com/microsoft/vscode/blob/f4fb3e71208ebe861a00581c47d2a98bf23f68a2/src/vs/platform/files/node/watcher/nodejs/nodejsWatcherLib.ts
`fs.watch` is called here:
https://github.com/microsoft/vscode/blob/f4fb3e71208ebe861a00581c47d2a98bf23f68a2/src/vs/platform/files/node/watcher/nodejs/nodejsWatcherLib.ts#L219

I think the reason why the GitExtension is sometimes slower than `fs.watchFile` is that it does that it debounces git operations, waits until they are idle, and the window is focused: https://github.com/microsoft/vscode/blob/f4fb3e71208ebe861a00581c47d2a98bf23f68a2/extensions/git/src/repository.ts#L2549-L2598

Meanwhile, `fs.watchFile` executes "immediately". I have not only noticed this in the tests, but also on a colleague's laptop, but it is never reproducible.

Another implementation path would be not to read from `repo.state` at all and just parse the contents of the `.git/HEAD` file, but I prefer this solution because it avoids registering yet another watcher.


