### PR TITLE
Add vscode.git as extension dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## Unreleased
+## [0.0.8] (https://github.com/kivicode/Jira-Commit-Message/compare/0.0.9...0.0.8)
+
+- Declare vscode.git as extension dependency
+
+## [0.0.8] (https://github.com/kivicode/Jira-Commit-Message/compare/0.0.8...0.0.7)
 
 - Removal of `gitHeadWatchInterval`, instead the `onDidChange` event of the GitExtension is used
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "git"
   ],
   "icon": "assets/icon.png",
+  "extensionDependencies": [
+    "vscode.git"
+  ],
   "activationEvents": [
     "onStartupFinished",
     "onDidCommit",


### PR DESCRIPTION
I have been getting 
```
2025-07-23 11:02:13.595 [error] Error: Extension 'vscode.git' is not known or not activated
	at zb.getActivatedExtension (file:///snap/code/198/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:120:10686)
	at yY.getExtensionExports (file:///snap/code/198/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:124:10931)
	at get exports (file:///snap/code/198/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:124:24578)
	at activate (/home/developerakademie/.vscode/extensions/kivicode.jira-commit-message-0.0.9/out/extension.js:130:70)
	at ky.kb (file:///snap/code/198/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:124:15268)
	at ky.jb (file:///snap/code/198/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:124:14975)
	at file:///snap/code/198/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:124:13133
	at async Wb.n (file:///snap/code/198/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:120:13382)
	at async Wb.m (file:///snap/code/198/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:120:13345)
	at async Wb.l (file:///snap/code/198/usr/share/code/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:120:12801)
```

a few times and did some digging around. It only appears sporadically. Maybe this will fix it.