### PR TITLE
Remove prefix when switching branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.0.10] (https://github.com/kivicode/Jira-Commit-Message/compare/0.0.9...0.0.10)
+- Remove previous prefix when switching branches
+
 ## [0.0.9] (https://github.com/kivicode/Jira-Commit-Message/compare/0.0.8...0.0.9)
 
 - Fix prefix duplication issue with character class patterns like `[A-Z]+`

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/kivicode/Jira-Commit-Message"
   },
   "description": "A VSCode extension for the automation of the adding of the relevant issue code to each commit message",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "engines": {
     "vscode": "^1.86.0"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ const LOG_PREFIX = "[Jira Commit Message]";
 interface ExtensionConfig {
   commitMessagePrefixPattern: RegExp;
   commitMessageFormat: string;
+  messageExtractionRegex: RegExp;
 }
 
 class RepositoryWatcher {
@@ -56,6 +57,7 @@ class RepositoryWatcher {
     this.config = newConfig;
 
     const currentMessage = extractCurrentMessage(this.repo, oldConfig);
+    // If the prefixPattern is changed, we need to extract the message with the old config.
     this.safeUpdateCommitMessage(currentMessage);
   }
 
@@ -75,13 +77,16 @@ function getExtensionConfig(): ExtensionConfig {
     "commitMessageFormat",
     "[${prefix}] ${message}"
   );
+  const commitMessagePrefixPattern = new RegExp(tagPattern);
 
-  const match = tagPattern.match(/\(([^)]+)\)/);
-  const prefixPattern = match ? match[1] : tagPattern;
-
+  const messageExtractionRegex = createMessageExtractionRegex(
+    msgFormat,
+    commitMessagePrefixPattern
+  );
   return {
-    commitMessagePrefixPattern: new RegExp(tagPattern),
+    commitMessagePrefixPattern,
     commitMessageFormat: msgFormat,
+    messageExtractionRegex: messageExtractionRegex,
   };
 }
 
@@ -100,8 +105,7 @@ function updateCommitMessage(
   if (typeof currentMessage === "undefined") {
     currentMessage = extractCurrentMessage(repo, config);
   }
-
-  const updatedMessage = getCommitMessage(branch, currentMessage, config);
+  const updatedMessage = buildCommitMessage(currentMessage, branch, config);
 
   if (repo.inputBox.value !== updatedMessage) {
     log(
@@ -118,64 +122,89 @@ function extractCurrentMessage(
   config: ExtensionConfig
 ): string {
   const currentValue = repo.inputBox.value;
-  const branch = repo.state.HEAD?.name ?? "";
-
-  if (branch && config.commitMessagePrefixPattern.test(branch)) {
-    const prefixMatch = branch.match(config.commitMessagePrefixPattern);
-    if (prefixMatch) {
-      const expectedPrefix = prefixMatch[1];
-      const expectedFormatted = config.commitMessageFormat
-        .replace("${prefix}", expectedPrefix)
-        .replace("${message}", "");
-
-      if (currentValue.startsWith(expectedFormatted)) {
-        return currentValue.substring(expectedFormatted.length).trim();
-      }
-    }
-  }
-
-  return currentValue;
+  const extractedMessage = extractMessageFromFormattedMessage(currentValue, config);
+  return extractedMessage.trim();
 }
 
-function getCommitMessage(
-  branch: string,
+function buildCommitMessage(
   currentMessage: string,
+  branch: string,
   config: ExtensionConfig
 ): string {
+  
+
+  // Doesn't match branch pattern? Leave as is.
   if (!config.commitMessagePrefixPattern.test(branch)) {
     return currentMessage;
   }
 
   const prefixMatch = branch.match(config.commitMessagePrefixPattern);
   if (!prefixMatch) {
+    // This shouldn't happen. We just checked it.
     return currentMessage;
   }
 
   const prefix = prefixMatch[1];
 
-  const formattedPrefix = config.commitMessageFormat
-    .replace("${prefix}", prefix)
-    .replace("${message}", "")
-    .trim();
-  if (currentMessage.startsWith(formattedPrefix)) {
-    return currentMessage;
-  }
-
-  const expectedFormatted = config.commitMessageFormat
-    .replace("${prefix}", prefix)
-    .replace("${message}", "");
-
-  let withoutExistingPrefix = currentMessage;
-  if (currentMessage.startsWith(expectedFormatted)) {
-    withoutExistingPrefix = currentMessage.substring(expectedFormatted.length);
-  }
-  withoutExistingPrefix = withoutExistingPrefix.trim();
-
+  // Build message according to message format
   const formattedMessage = config.commitMessageFormat
     .replace("${prefix}", prefix)
-    .replace("${message}", withoutExistingPrefix);
+    .replace("${message}", currentMessage);
 
   return formattedMessage;
+}
+
+function extractMessageFromFormattedMessage(
+  message: string,
+  config: ExtensionConfig
+): string {
+  const match = message.match(config.messageExtractionRegex);
+  return match?.groups?.message ?? message;
+}
+
+function createMessageExtractionRegex(
+  format: string,
+  commitMessagePrefixPattern: RegExp
+): RegExp {
+  const prefixToken = "${prefix}";
+  const messageToken = "${message}";
+  const fallbackMessageRegex = /^(?<message>.*)$/;
+
+  if (!format.includes(prefixToken) || !format.includes(messageToken)) {
+    console.error(
+      `${LOG_PREFIX} commitMessageFormat must contain both ${prefixToken} and ${messageToken}. Falling back to message passthrough regex.`
+    );
+    return fallbackMessageRegex;
+  }
+
+  const branchPrefixPattern = getBranchPrefixPattern(commitMessagePrefixPattern);
+  if (!branchPrefixPattern) {
+    console.error(
+      `${LOG_PREFIX} commitMessagePrefixPattern must contain a capture group for the prefix. Falling back to message passthrough regex.`
+    );
+    return fallbackMessageRegex;
+  }
+
+  const escapedFormat = escapeRegExp(format);
+  const patternWithPrefix = escapedFormat.replace(
+    escapeRegExp(prefixToken),
+    `(?:${branchPrefixPattern})`
+  );
+  const fullPattern = patternWithPrefix.replace(
+    escapeRegExp(messageToken),
+    "(?<message>.*)"
+  );
+
+  return new RegExp(`^${fullPattern}$`);
+}
+
+function getBranchPrefixPattern(prefixPattern: RegExp): string | undefined {
+  const firstGroupMatch = prefixPattern.source.match(/\(([^)]+)\)/);
+  return firstGroupMatch?.[1];
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 export function activate(context: vscode.ExtensionContext): void {
@@ -193,7 +222,11 @@ export function activate(context: vscode.ExtensionContext): void {
   const git = gitExtension.getAPI(1);
   let config = getExtensionConfig();
   outputChannel.appendLine(
-    `${LOG_PREFIX} Loaded configuration ${JSON.stringify(config)}`
+    `${LOG_PREFIX} Loaded configuration `+
+    `{commitMessageFormat: '${config.commitMessageFormat}', ` +
+    // Regex can't be printed with JSON.stringify
+    `commitMessagePrefixPattern: ${config.commitMessagePrefixPattern}, ` +
+    `messageExtractionRegex: ${config.messageExtractionRegex}}`
   );
 
   const repoWatchers: RepositoryWatcher[] = [];

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -19,7 +19,7 @@ async function main() {
       extensionDevelopmentPath,
       extensionTestsPath,
       version: process.env.VSCODE_VERSION || "1.95.0",
-      launchArgs: ["--disable-gpu", "--no-sandbox", workspaceFolder],
+      launchArgs: ["--disable-gpu", "--no-sandbox", "--profile-temp", workspaceFolder],
     });
   } catch (err) {
     console.error("Failed to run tests", err);

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -19,7 +19,11 @@ async function main() {
       extensionDevelopmentPath,
       extensionTestsPath,
       version: process.env.VSCODE_VERSION || "1.95.0",
-      launchArgs: ["--disable-gpu", "--no-sandbox", "--profile-temp", workspaceFolder],
+      launchArgs: ["--disable-gpu",
+        "--no-sandbox",
+        // Avoids interference with locally installed extensions
+         "--profile-temp",
+         workspaceFolder],
     });
   } catch (err) {
     console.error("Failed to run tests", err);

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -269,6 +269,21 @@ suite("Jira Commit Message Extension", function () {
     await assertCommitMessage("[NEW-789] [OLD-123] Some existing work");
   });
 
+  test("should replace existing leading prefix when switching between matching branches", async function () {
+    await updateConfig({
+      commitMessagePrefixPattern: "(PP-\\d+)-.*",
+      commitMessageFormat: "[${prefix}] ${message}",
+    });
+    const repo = gitApi.repositories[0];
+
+    repo.inputBox.value = "Implement branch switch behavior";
+    await switchToBranch("PP-101-first-branch");
+    await assertCommitMessage("[PP-101] Implement branch switch behavior");
+
+    await switchToBranch("PP-202-second-branch");
+    await assertCommitMessage("[PP-202] Implement branch switch behavior");
+  });
+
   test("should work with numeric-only prefixes", async function () {
     // Real scenario: Some teams use just numbers for tickets
     await updateConfig({


### PR DESCRIPTION
Hi @kivicode ,

This MR solves the issue of stacking up prefixes when switching patterns, because the current code doesn't clean up after itself, so if you go from `branch-1` to `branch-2` your commit message will be `[branch-2] [branch-1] ...`
